### PR TITLE
Improve TaskHistory value display with word wrapping

### DIFF
--- a/frontend/src/components/TaskHistory.jsx
+++ b/frontend/src/components/TaskHistory.jsx
@@ -22,8 +22,7 @@ function formatValue(field, value) {
     const d = new Date(value.slice(0, 10) + 'T00:00:00');
     return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
   }
-  // Truncate long strings so they fit on one row
-  return value.length > 40 ? value.slice(0, 40) + '…' : value;
+  return value;
 }
 
 function formatTime(isoStr) {
@@ -72,13 +71,13 @@ export default function TaskHistory({ taskId }) {
               <td className="py-2 pr-4 font-medium text-gray-600 whitespace-nowrap">
                 {FIELD_LABELS[entry.field] ?? entry.field}
               </td>
-              <td className="py-2 pr-2 max-w-[10rem] truncate">
+              <td className="py-2 pr-2 max-w-[10rem] break-words">
                 <span className="bg-red-50 text-red-500 px-1.5 py-0.5 rounded line-through">
                   {formatValue(entry.field, entry.old_value)}
                 </span>
               </td>
               <td className="py-2 pr-2 text-gray-300 select-none">→</td>
-              <td className="py-2 max-w-[10rem] truncate">
+              <td className="py-2 max-w-[10rem] break-words">
                 <span className="bg-green-50 text-green-700 px-1.5 py-0.5 rounded">
                   {formatValue(entry.field, entry.new_value)}
                 </span>


### PR DESCRIPTION
## Summary
Updated the TaskHistory component to display full values without truncation, using CSS word wrapping instead of JavaScript string truncation for better readability and user experience.

## Key Changes
- Removed the 40-character truncation logic from `formatValue()` function that was appending ellipsis to long strings
- Replaced `truncate` CSS class with `break-words` on both old and new value table cells to allow text wrapping within the max-width constraint
- Values now display in full across multiple lines instead of being cut off at 40 characters

## Implementation Details
- The change maintains the `max-w-[10rem]` width constraint on the cells, but allows content to wrap naturally rather than being clipped
- This provides better visibility of complete field values in the task history, which is important for audit/change tracking purposes
- The CSS-based approach (`break-words`) is more flexible than the previous JavaScript truncation and respects the container width constraints

https://claude.ai/code/session_01VhgSy6rCV516DT9iGDc88V